### PR TITLE
allow .atoum.yml file to be absent

### DIFF
--- a/classes/container.php
+++ b/classes/container.php
@@ -26,9 +26,14 @@ class container
             ->addCompilerPass(new config\container\compiler\directories($script))
         ;
 
-        $loader = new YamlFileLoader($this->container, new FileLocator(array(__DIR__ . '/../resources', getcwd())));
+        $loader = new YamlFileLoader($this->container, new FileLocator(array(__DIR__ . '/../resources')));
         $loader->load('services.yml');
-        $loader->load('.atoum.yml');
+
+        $configFile = getcwd() . DIRECTORY_SEPARATOR . '.atoum.yml';
+        if (is_file($configFile)) {
+            $loader = new YamlFileLoader($this->container, new FileLocator());
+            $loader->load($configFile);
+        }
 
         $this->container->compile();
     }


### PR DESCRIPTION
In order to load the extension and still leave the user to choice to load
the .atoum.php or the .atoum.yml file, we need to avoid having an exception
when the file is not present.

So when catch the exception if the file has not been found in the folders.
