### PR TITLE
moving dependancies from the dev section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
             "email": "contact@jubianchi.fr"
         }
     ],
-    "require-dev": {
+    "require": {
         "atoum/atoum": "<3.0",
         "symfony/yaml": "~2.6",
         "symfony/config": "~2.6",


### PR DESCRIPTION
The extension dependancies were in the require-dev section.
So, when requiring atoum/config-extension, they were not loaded.
Now, composer will ensure that those dependancies will be present.
