### PR TITLE
Avoid deprecated error when using symfony/yaml >= 2.8

### DIFF
--- a/resources/services.yml
+++ b/resources/services.yml
@@ -31,32 +31,32 @@ services:
     report.coverage.clover:
         class: mageekguy\atoum\reports\asynchronous\clover
         calls:
-            - [addWriter, [@writer.clover]]
+            - [addWriter, ["@writer.clover"]]
 
     report.xunit:
         class: mageekguy\atoum\reports\asynchronous\xunit
         calls:
-            - [addWriter, [@writer.xunit]]
+            - [addWriter, ["@writer.xunit"]]
 
     report.vim:
         class: mageekguy\atoum\reports\asynchronous\vim
         calls:
-            - [addWriter, [@writer.stdout]]
+            - [addWriter, ["@writer.stdout"]]
 
     report.nyancat:
         class: mageekguy\atoum\reports\realtime\nyancat
         calls:
-            - [addWriter, [@writer.stdout]]
+            - [addWriter, ["@writer.stdout"]]
 
     report.santa:
         class: mageekguy\atoum\reports\realtime\santa
         calls:
-            - [addWriter, [@writer.stdout]]
+            - [addWriter, ["@writer.stdout"]]
 
     report.tap:
         class: mageekguy\atoum\reports\realtime\tap
         calls:
-            - [addWriter, [@writer.stdout]]
+            - [addWriter, ["@writer.stdout"]]
 
     writer.mailer:
         class: mageekguy\atoum\mailers\mail


### PR DESCRIPTION
Using symfony/yaml >= 2.8 we were getting this error:

```
E_USER_DEPRECATED: Not quoting the scalar "@writer.clover" starting with "@" is deprecated since Symfony 2.8 and will throw a ParseException in 3.0. in vendor/symfony/yaml/Inline.php on line 259
```
