### PR TITLE
Compatibility with Symfony 4.2+

### DIFF
--- a/classes/configuration/definition.php
+++ b/classes/configuration/definition.php
@@ -11,11 +11,11 @@ class definition implements ConfigurationInterface
 	
 	public function getConfigTreeBuilder()
 	{
-		if (method_exists($tree, 'getRootNode')) { // conpatibility with symfony config 4.2+
+		if (method_exists(TreeBuilder::class, '__construct')) { // conpatibility with symfony config 4.2+
 			$tree = new TreeBuilder(self::ROOT_NODE_NAME);
 			$root = $tree->getRootNode();
 		} else {
-			// remove this `else` when symfony config requirements is 4.2+
+			// TODO remove this `else` when symfony config requirements is 4.2+
 			$tree = new TreeBuilder();
 			$root = $tree->root(self::ROOT_NODE_NAME);
 		}		

--- a/classes/configuration/definition.php
+++ b/classes/configuration/definition.php
@@ -7,10 +7,18 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class definition implements ConfigurationInterface
 {
+	const ROOT_NODE_NAME = 'atoum';
+	
 	public function getConfigTreeBuilder()
 	{
-		$tree = new TreeBuilder();
-		$root = $tree->root('atoum');
+		if (method_exists($tree, 'getRootNode')) { // conpatibility with symfony config 4.2+
+			$tree = new TreeBuilder(self::ROOT_NODE_NAME);
+			$root = $tree->getRootNode();
+		} else {
+			// remove this `else` when symfony config requirements is 4.2+
+			$tree = new TreeBuilder();
+			$root = $tree->root(self::ROOT_NODE_NAME);
+		}		
 
 		$root
 			->children()

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "minimum-stability": "beta",
     "require": {
-        "atoum/atoum": "^2.9||^3.0",
+        "atoum/atoum": "^2.9||^3.0||^4.0",
         "symfony/yaml": "^2.6||^3.0||^4.0",
         "symfony/config": "^2.6||^3.0||^4.0",
         "symfony/dependency-injection": "^2.6||^3.0||^4.0"


### PR DESCRIPTION
`TreeBuilder` now takes the root node name in the constructor.